### PR TITLE
Add a Codacy badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/b7a114c241444b6c863c884178fb6af6)](https://app.codacy.com/gh/Terry-BrooksJr/the-dozens-django?utm_source=github.com&utm_medium=referral&utm_content=Terry-BrooksJr/the-dozens-django&utm_campaign=Badge_Grade)
 [![CI Pipeline](https://github.com/Terry-BrooksJr/the-dozens-django/actions/workflows/commit_check.yaml/badge.svg)](https://github.com/Terry-BrooksJr/the-dozens-django/actions/workflows/commit_check.yaml)
 # The Dozens — Django/DRF API
 


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Display Codacy code quality status in the README via a badge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added code quality coverage badge and CI pipeline status indicator to project documentation for improved visibility of code quality metrics and build status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->