### PR TITLE
Add comprehensive tests for metrics and middleware functionality

### DIFF
--- a/.deploy/prometheus.yml
+++ b/.deploy/prometheus.yml
@@ -25,11 +25,14 @@ scrape_configs:
 
   # ── Django API ─────────────────────────────────────────────────────────────
   # Scraped directly from the published container port, bypassing Traefik.
-  # REMOTE_ADDR inside the container will be 172.28.0.1 (bridge gateway) —
-  # that IP is included in PROMETHEUS_ALLOWED_HOSTS alongside 165.227.105.209.
+  # Auth is a bearer token (METRICS_SCRAPE_TOKEN in Doppler) — IP allowlists
+  # were dropped because Docker NAT makes REMOTE_ADDR unreliable.
   - job_name: django
     scrape_interval: 15s
     metrics_path: /metrics
+    authorization:
+      type: Bearer
+      credentials_file: /etc/prometheus/metrics_token
     static_configs:
       - targets:
           - localhost:9090

--- a/common/cache_managers.py
+++ b/common/cache_managers.py
@@ -41,7 +41,7 @@ class BaseCacheManager(ABC):
         self.model_class = model_class
         self.cache_prefix = cache_prefix or model_class.__name__
         self.cache_timeout = getattr(self, "CACHE_TIMEOUT", 86400)  # 24 hours default
-        self._cache_lock = threading.Lock()
+        self._cache_lock = threading.RLock()  # RLock allows re-entry from the same thread
 
     @abstractmethod
     def get_cache_keys(self) -> Dict[str, str]:

--- a/common/cache_managers.py
+++ b/common/cache_managers.py
@@ -41,7 +41,9 @@ class BaseCacheManager(ABC):
         self.model_class = model_class
         self.cache_prefix = cache_prefix or model_class.__name__
         self.cache_timeout = getattr(self, "CACHE_TIMEOUT", 86400)  # 24 hours default
-        self._cache_lock = threading.RLock()  # RLock allows re-entry from the same thread
+        self._cache_lock = (
+            threading.RLock()
+        )  # RLock allows re-entry from the same thread
 
     @abstractmethod
     def get_cache_keys(self) -> Dict[str, str]:

--- a/common/tests/test_cache_managers.py
+++ b/common/tests/test_cache_managers.py
@@ -86,7 +86,7 @@ def _make_generic_manager(model_class=None, prefix="test", builder=None, timeout
 
 
 class CacheManagerRegistryTests(TestCase):
-        """Tests the behavior of the CacheManagerRegistry utility class. These tests verify that cache managers can be registered, queried, invalidated, and inspected for statistics."""
+    """Tests the behavior of the CacheManagerRegistry utility class. These tests verify that cache managers can be registered, queried, invalidated, and inspected for statistics."""
     def test_names_returns_registered_names(self):
         """Registered cache manager names are exposed via names() The method should return all manager identifiers that have been added to the registry."""
         reg = self._fresh_registry()
@@ -99,7 +99,6 @@ class CacheManagerRegistryTests(TestCase):
         return CacheManagerRegistry()
 
     def test_register_and_get(self):
-        """Registering a manager makes it retrievable by its name. The registry should return the same manager instance that was originally registered."""
         """Registering a manager makes it retrievable by its name. The registry should return the same manager instance that was originally registered."""
         reg = self._fresh_registry()
         mgr = MagicMock(spec=BaseCacheManager)
@@ -188,7 +187,6 @@ class CacheManagerRegistryTests(TestCase):
 
 
 class CategoryCacheManagerTests(TestCase):
-    """Tests the behavior of the CategoryCacheManager class. These tests verify that category data is cached, retrieved, invalidated, and mapped between keys and names correctly."""
     """Tests the behavior of the CategoryCacheManager class. These tests verify that category data is cached, retrieved, invalidated, and mapped between keys and names correctly."""
     def _make_obj(self, key, name):
         obj = MagicMock()
@@ -329,7 +327,6 @@ class CategoryCacheManagerTests(TestCase):
 
 class GenericDataCacheManagerTests(TestCase):
     """Tests the behavior of the GenericDataCacheManager class. These tests verify that generic data is cached, retrieved, invalidated, and reported on consistently across different backends."""
-    """Tests the behavior of the GenericDataCacheManager class. These tests verify that generic data is cached, retrieved, invalidated, and reported on consistently across different backends."""
     def test_get_cache_keys_returns_data_key(self):
         mgr = _make_generic_manager(prefix="myprefix")
         keys = mgr.get_cache_keys()
@@ -436,7 +433,6 @@ class GenericDataCacheManagerTests(TestCase):
 
 
 class FormChoicesCacheManagerTests(TestCase):
-    """Tests the behavior of the FormChoicesCacheManager class. These tests verify that form choice data and related querysets are built, cached, retrieved, and invalidated correctly."""
     """Tests the behavior of the FormChoicesCacheManager class. These tests verify that form choice data and related querysets are built, cached, retrieved, and invalidated correctly."""
 
     def _make_manager(self, choice_data=None, prefix="form_test"):

--- a/common/tests/test_cache_managers.py
+++ b/common/tests/test_cache_managers.py
@@ -43,24 +43,24 @@ Factory functions
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from common.cache_managers import (
     BaseCacheManager,
-    CategoryCacheManager,
     CacheManagerRegistry,
+    CategoryCacheManager,
     FormChoicesCacheManager,
     GenericDataCacheManager,
     create_category_manager,
     create_form_choices_manager,
 )
 
-
 # ---------------------------------------------------------------------------
 # Shared helpers / fake model
 # ---------------------------------------------------------------------------
+
 
 def _make_model_class(name="FakeModel", objects=None):
     """Return a minimal model-class-like object."""
@@ -83,6 +83,7 @@ def _make_generic_manager(model_class=None, prefix="test", builder=None, timeout
 # ---------------------------------------------------------------------------
 # CacheManagerRegistry
 # ---------------------------------------------------------------------------
+
 
 class CacheManagerRegistryTests(TestCase):
 
@@ -172,6 +173,7 @@ class CacheManagerRegistryTests(TestCase):
 # ---------------------------------------------------------------------------
 # CategoryCacheManager
 # ---------------------------------------------------------------------------
+
 
 class CategoryCacheManagerTests(TestCase):
 
@@ -311,6 +313,7 @@ class CategoryCacheManagerTests(TestCase):
 # GenericDataCacheManager
 # ---------------------------------------------------------------------------
 
+
 class GenericDataCacheManagerTests(TestCase):
 
     def test_get_cache_keys_returns_data_key(self):
@@ -361,6 +364,7 @@ class GenericDataCacheManagerTests(TestCase):
 
     def test_get_cached_data_programming_error_returns_none(self):
         from django.db.utils import ProgrammingError
+
         builder = MagicMock(side_effect=ProgrammingError("table missing"))
         mgr = _make_generic_manager(prefix="dberr", builder=builder)
 
@@ -398,8 +402,14 @@ class GenericDataCacheManagerTests(TestCase):
             mock_cache.get_many.return_value = {}
             stats = mgr.get_cache_stats()
 
-        for key in ("cache_prefix", "redis_keys", "redis_keys_count",
-                    "module_cache_count", "cache_timeout", "timestamp"):
+        for key in (
+            "cache_prefix",
+            "redis_keys",
+            "redis_keys_count",
+            "module_cache_count",
+            "cache_timeout",
+            "timestamp",
+        ):
             self.assertIn(key, stats)
 
         self.assertEqual(stats["cache_prefix"], "stats_test")
@@ -409,6 +419,7 @@ class GenericDataCacheManagerTests(TestCase):
 # ---------------------------------------------------------------------------
 # FormChoicesCacheManager
 # ---------------------------------------------------------------------------
+
 
 class FormChoicesCacheManagerTests(TestCase):
 
@@ -491,10 +502,12 @@ class FormChoicesCacheManagerTests(TestCase):
 # Factory functions
 # ---------------------------------------------------------------------------
 
+
 class FactoryFunctionTests(TestCase):
 
     def test_create_form_choices_manager_returns_instance(self):
         from common.cache_managers import cache_registry
+
         model = _make_model_class("FactoryModel")
         model.objects.filter.return_value.values.return_value = []
 
@@ -509,6 +522,7 @@ class FactoryFunctionTests(TestCase):
 
     def test_create_category_manager_returns_instance(self):
         from common.cache_managers import cache_registry
+
         model = _make_model_class("FactoryCatModel")
         model.objects.all.return_value = []
 

--- a/common/tests/test_cache_managers.py
+++ b/common/tests/test_cache_managers.py
@@ -86,11 +86,20 @@ def _make_generic_manager(model_class=None, prefix="test", builder=None, timeout
 
 
 class CacheManagerRegistryTests(TestCase):
+        """Tests the behavior of the CacheManagerRegistry utility class. These tests verify that cache managers can be registered, queried, invalidated, and inspected for statistics."""
+    def test_names_returns_registered_names(self):
+        """Registered cache manager names are exposed via names(). The method should return all manager identifiers that have been added to the registry."""
+        reg = self._fresh_registry()
+        reg.register("alpha", MagicMock())
+        reg.register("beta", MagicMock())
+        self.assertIn("alpha", reg.names())
+        self.assertIn("beta", reg.names())
 
     def _fresh_registry(self):
         return CacheManagerRegistry()
 
     def test_register_and_get(self):
+        """Registering a manager makes it retrievable by its name. The registry should return the same manager instance that was originally registered."""
         reg = self._fresh_registry()
         mgr = MagicMock(spec=BaseCacheManager)
         reg.register("my_manager", mgr)
@@ -134,6 +143,7 @@ class CacheManagerRegistryTests(TestCase):
         self.assertEqual(vals, [mgr])
 
     def test_invalidate_all_calls_each_manager(self):
+        """Invalidate all propagates the request to every registered manager. Each manager should receive a single invalidate_cache call with the given reason."""
         reg = self._fresh_registry()
         m1, m2 = MagicMock(), MagicMock()
         reg.register("m1", m1)
@@ -176,7 +186,7 @@ class CacheManagerRegistryTests(TestCase):
 
 
 class CategoryCacheManagerTests(TestCase):
-
+    """Tests the behavior of the CategoryCacheManager class. These tests verify that category data is cached, retrieved, invalidated, and mapped between keys and names correctly."""
     def _make_obj(self, key, name):
         obj = MagicMock()
         obj.key = key
@@ -315,7 +325,7 @@ class CategoryCacheManagerTests(TestCase):
 
 
 class GenericDataCacheManagerTests(TestCase):
-
+    """Tests the behavior of the GenericDataCacheManager class. These tests verify that generic data is cached, retrieved, invalidated, and reported on consistently across different backends."""
     def test_get_cache_keys_returns_data_key(self):
         mgr = _make_generic_manager(prefix="myprefix")
         keys = mgr.get_cache_keys()
@@ -422,6 +432,7 @@ class GenericDataCacheManagerTests(TestCase):
 
 
 class FormChoicesCacheManagerTests(TestCase):
+    """Tests the behavior of the FormChoicesCacheManager class. These tests verify that form choice data and related querysets are built, cached, retrieved, and invalidated correctly."""
 
     def _make_manager(self, choice_data=None, prefix="form_test"):
         """Return a FormChoicesCacheManager with mocked model."""
@@ -504,6 +515,7 @@ class FormChoicesCacheManagerTests(TestCase):
 
 
 class FactoryFunctionTests(TestCase):
+    """Tests the behavior of cache manager factory functions. These tests verify that factory helpers create the correct manager instances and automatically register them in the shared cache registry."""
 
     def test_create_form_choices_manager_returns_instance(self):
         from common.cache_managers import cache_registry

--- a/common/tests/test_cache_managers.py
+++ b/common/tests/test_cache_managers.py
@@ -109,13 +109,6 @@ class CacheManagerRegistryTests(TestCase):
         reg = self._fresh_registry()
         self.assertIsNone(reg.get("does_not_exist"))
 
-    def test_names_returns_registered_names(self):
-        reg = self._fresh_registry()
-        reg.register("alpha", MagicMock())
-        reg.register("beta", MagicMock())
-        self.assertIn("alpha", reg.names())
-        self.assertIn("beta", reg.names())
-
     def test_count(self):
         reg = self._fresh_registry()
         self.assertEqual(reg.count(), 0)
@@ -516,7 +509,6 @@ class FormChoicesCacheManagerTests(TestCase):
 
 
 class FactoryFunctionTests(TestCase):
-    """Tests the behavior of cache manager factory functions. These tests verify that factory helpers create the correct manager instances and automatically register them in the shared cache registry."""
     """Tests the behavior of cache manager factory functions. These tests verify that factory helpers create the correct manager instances and automatically register them in the shared cache registry."""
 
     def test_create_form_choices_manager_returns_instance(self):

--- a/common/tests/test_cache_managers.py
+++ b/common/tests/test_cache_managers.py
@@ -88,7 +88,7 @@ def _make_generic_manager(model_class=None, prefix="test", builder=None, timeout
 class CacheManagerRegistryTests(TestCase):
         """Tests the behavior of the CacheManagerRegistry utility class. These tests verify that cache managers can be registered, queried, invalidated, and inspected for statistics."""
     def test_names_returns_registered_names(self):
-        """Registered cache manager names are exposed via names(). The method should return all manager identifiers that have been added to the registry."""
+        """Registered cache manager names are exposed via names() The method should return all manager identifiers that have been added to the registry."""
         reg = self._fresh_registry()
         reg.register("alpha", MagicMock())
         reg.register("beta", MagicMock())
@@ -99,6 +99,7 @@ class CacheManagerRegistryTests(TestCase):
         return CacheManagerRegistry()
 
     def test_register_and_get(self):
+        """Registering a manager makes it retrievable by its name. The registry should return the same manager instance that was originally registered."""
         """Registering a manager makes it retrievable by its name. The registry should return the same manager instance that was originally registered."""
         reg = self._fresh_registry()
         mgr = MagicMock(spec=BaseCacheManager)
@@ -144,6 +145,7 @@ class CacheManagerRegistryTests(TestCase):
 
     def test_invalidate_all_calls_each_manager(self):
         """Invalidate all propagates the request to every registered manager. Each manager should receive a single invalidate_cache call with the given reason."""
+        """Invalidate all propagates the request to every registered manager. Each manager should receive a single invalidate_cache call with the given reason."""
         reg = self._fresh_registry()
         m1, m2 = MagicMock(), MagicMock()
         reg.register("m1", m1)
@@ -186,6 +188,7 @@ class CacheManagerRegistryTests(TestCase):
 
 
 class CategoryCacheManagerTests(TestCase):
+    """Tests the behavior of the CategoryCacheManager class. These tests verify that category data is cached, retrieved, invalidated, and mapped between keys and names correctly."""
     """Tests the behavior of the CategoryCacheManager class. These tests verify that category data is cached, retrieved, invalidated, and mapped between keys and names correctly."""
     def _make_obj(self, key, name):
         obj = MagicMock()
@@ -326,6 +329,7 @@ class CategoryCacheManagerTests(TestCase):
 
 class GenericDataCacheManagerTests(TestCase):
     """Tests the behavior of the GenericDataCacheManager class. These tests verify that generic data is cached, retrieved, invalidated, and reported on consistently across different backends."""
+    """Tests the behavior of the GenericDataCacheManager class. These tests verify that generic data is cached, retrieved, invalidated, and reported on consistently across different backends."""
     def test_get_cache_keys_returns_data_key(self):
         mgr = _make_generic_manager(prefix="myprefix")
         keys = mgr.get_cache_keys()
@@ -433,6 +437,7 @@ class GenericDataCacheManagerTests(TestCase):
 
 class FormChoicesCacheManagerTests(TestCase):
     """Tests the behavior of the FormChoicesCacheManager class. These tests verify that form choice data and related querysets are built, cached, retrieved, and invalidated correctly."""
+    """Tests the behavior of the FormChoicesCacheManager class. These tests verify that form choice data and related querysets are built, cached, retrieved, and invalidated correctly."""
 
     def _make_manager(self, choice_data=None, prefix="form_test"):
         """Return a FormChoicesCacheManager with mocked model."""
@@ -515,6 +520,7 @@ class FormChoicesCacheManagerTests(TestCase):
 
 
 class FactoryFunctionTests(TestCase):
+    """Tests the behavior of cache manager factory functions. These tests verify that factory helpers create the correct manager instances and automatically register them in the shared cache registry."""
     """Tests the behavior of cache manager factory functions. These tests verify that factory helpers create the correct manager instances and automatically register them in the shared cache registry."""
 
     def test_create_form_choices_manager_returns_instance(self):

--- a/common/tests/test_cache_managers.py
+++ b/common/tests/test_cache_managers.py
@@ -1,0 +1,518 @@
+"""
+Tests for common.cache_managers.
+
+Covers:
+CacheManagerRegistry
+  - register / get / names / count / all / items / values
+  - invalidate_all: calls each manager's invalidate_cache
+  - invalidate_all: continues past a manager that raises
+  - get_all_stats: returns stats dict; skips managers without get_cache_stats
+  - get returns None for unknown name
+
+CategoryCacheManager
+  - get_cache_keys: returns expected key structure
+  - build_data_from_db: maps key_field → name_field correctly
+  - build_data_from_db: returns empty dict on exception
+  - get_all_categories: populates from DB on cache miss; returns cached value on hit
+  - get_category_name_by_key: Redis hit path / fallback to all_categories
+  - get_category_key_by_name: Redis hit path / fallback (case-insensitive)
+  - set_category_name_mapping: writes both directions into cache
+  - invalidate_category: deletes correct cache keys
+
+GenericDataCacheManager
+  - get_cache_keys returns expected key
+  - get_cached_data: module-level cache hit (no Django cache call)
+  - get_cached_data: Redis hit populates module cache
+  - get_cached_data: cache miss calls data builder and stores result
+  - get_cached_data: invalid cache_key name returns None
+  - get_cached_data: DB ProgrammingError returns None gracefully
+  - invalidate_cache: clears both caches
+  - get_cache_stats: returns a dict with expected keys
+
+FormChoicesCacheManager
+  - get_form_choices: returns cached choices list
+  - get_queryset_json: returns cached JSON string
+  - get_choices_and_queryset: returns both together
+  - _build_form_choices_data: builds (value, display) tuples from queryset
+
+Factory functions
+  - create_form_choices_manager: creates and auto-registers manager
+  - create_category_manager: creates and auto-registers manager
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch, PropertyMock
+
+from django.test import TestCase, override_settings
+
+from common.cache_managers import (
+    BaseCacheManager,
+    CategoryCacheManager,
+    CacheManagerRegistry,
+    FormChoicesCacheManager,
+    GenericDataCacheManager,
+    create_category_manager,
+    create_form_choices_manager,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers / fake model
+# ---------------------------------------------------------------------------
+
+def _make_model_class(name="FakeModel", objects=None):
+    """Return a minimal model-class-like object."""
+    m = MagicMock()
+    m.__name__ = name
+    m.objects = objects or MagicMock()
+    return m
+
+
+def _make_generic_manager(model_class=None, prefix="test", builder=None, timeout=60):
+    mc = model_class or _make_model_class()
+    return GenericDataCacheManager(
+        model_class=mc,
+        cache_prefix=prefix,
+        data_builder=builder,
+        cache_timeout=timeout,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CacheManagerRegistry
+# ---------------------------------------------------------------------------
+
+class CacheManagerRegistryTests(TestCase):
+
+    def _fresh_registry(self):
+        return CacheManagerRegistry()
+
+    def test_register_and_get(self):
+        reg = self._fresh_registry()
+        mgr = MagicMock(spec=BaseCacheManager)
+        reg.register("my_manager", mgr)
+        self.assertIs(reg.get("my_manager"), mgr)
+
+    def test_get_unknown_returns_none(self):
+        reg = self._fresh_registry()
+        self.assertIsNone(reg.get("does_not_exist"))
+
+    def test_names_returns_registered_names(self):
+        reg = self._fresh_registry()
+        reg.register("alpha", MagicMock())
+        reg.register("beta", MagicMock())
+        self.assertIn("alpha", reg.names())
+        self.assertIn("beta", reg.names())
+
+    def test_count(self):
+        reg = self._fresh_registry()
+        self.assertEqual(reg.count(), 0)
+        reg.register("one", MagicMock())
+        self.assertEqual(reg.count(), 1)
+
+    def test_all_returns_shallow_copy(self):
+        reg = self._fresh_registry()
+        mgr = MagicMock()
+        reg.register("x", mgr)
+        snapshot = reg.all()
+        self.assertIsInstance(snapshot, dict)
+        self.assertIs(snapshot["x"], mgr)
+        # Mutating the snapshot doesn't affect the registry
+        del snapshot["x"]
+        self.assertIsNotNone(reg.get("x"))
+
+    def test_items_and_values_iteration(self):
+        reg = self._fresh_registry()
+        mgr = MagicMock()
+        reg.register("z", mgr)
+        pairs = list(reg.items())
+        self.assertEqual(pairs, [("z", mgr)])
+        vals = list(reg.values())
+        self.assertEqual(vals, [mgr])
+
+    def test_invalidate_all_calls_each_manager(self):
+        reg = self._fresh_registry()
+        m1, m2 = MagicMock(), MagicMock()
+        reg.register("m1", m1)
+        reg.register("m2", m2)
+        reg.invalidate_all("test_reason")
+        m1.invalidate_cache.assert_called_once_with("test_reason")
+        m2.invalidate_cache.assert_called_once_with("test_reason")
+
+    def test_invalidate_all_continues_past_exception(self):
+        """A manager that raises must not prevent others from being invalidated."""
+        reg = self._fresh_registry()
+        bad = MagicMock()
+        bad.invalidate_cache.side_effect = RuntimeError("oops")
+        good = MagicMock()
+        reg.register("bad", bad)
+        reg.register("good", good)
+        reg.invalidate_all("reason")  # must not raise
+        good.invalidate_cache.assert_called_once()
+
+    def test_get_all_stats_includes_managers_with_stats(self):
+        reg = self._fresh_registry()
+        mgr = MagicMock()
+        mgr.get_cache_stats.return_value = {"hits": 5}
+        reg.register("stats_mgr", mgr)
+        stats = reg.get_all_stats()
+        self.assertIn("stats_mgr", stats)
+        self.assertEqual(stats["stats_mgr"]["hits"], 5)
+
+    def test_get_all_stats_skips_managers_without_method(self):
+        reg = self._fresh_registry()
+        mgr = MagicMock(spec=[])  # no get_cache_stats
+        reg.register("no_stats", mgr)
+        stats = reg.get_all_stats()
+        self.assertNotIn("no_stats", stats)
+
+
+# ---------------------------------------------------------------------------
+# CategoryCacheManager
+# ---------------------------------------------------------------------------
+
+class CategoryCacheManagerTests(TestCase):
+
+    def _make_obj(self, key, name):
+        obj = MagicMock()
+        obj.key = key
+        obj.name = name
+        return obj
+
+    def test_get_cache_keys_structure(self):
+        model = _make_model_class()
+        mgr = CategoryCacheManager(model)
+        keys = mgr.get_cache_keys()
+        self.assertIn("all", keys)
+        self.assertIn("name_prefix", keys)
+        self.assertIn("key_prefix", keys)
+
+    def test_build_data_from_db_maps_correctly(self):
+        obj1 = self._make_obj("P", "Poor")
+        obj2 = self._make_obj("D", "Dark")
+        model = _make_model_class()
+        model.objects.all.return_value = [obj1, obj2]
+        mgr = CategoryCacheManager(model)
+        result = mgr.build_data_from_db()
+        self.assertEqual(result["all"], {"P": "Poor", "D": "Dark"})
+
+    def test_build_data_from_db_returns_empty_on_exception(self):
+        model = _make_model_class()
+        model.objects.all.side_effect = Exception("db down")
+        mgr = CategoryCacheManager(model)
+        result = mgr.build_data_from_db()
+        self.assertEqual(result["all"], {})
+
+    def test_get_all_categories_populates_from_db_on_cache_miss(self):
+        obj = self._make_obj("P", "Poor")
+        model = _make_model_class()
+        model.objects.all.return_value = [obj]
+        mgr = CategoryCacheManager(model)
+
+        with patch("common.cache_managers.cache") as mock_cache:
+            mock_cache.get.return_value = None  # cache miss
+            mock_cache.set = MagicMock()
+            result = mgr.get_all_categories()
+
+        self.assertEqual(result, {"P": "Poor"})
+        mock_cache.set.assert_called()
+
+    def test_get_all_categories_returns_cached_value(self):
+        model = _make_model_class()
+        mgr = CategoryCacheManager(model)
+
+        with patch("common.cache_managers.cache") as mock_cache:
+            mock_cache.get.return_value = {"X": "Extreme"}
+            result = mgr.get_all_categories()
+
+        model.objects.all.assert_not_called()
+        self.assertEqual(result, {"X": "Extreme"})
+
+    def test_get_category_name_by_key_redis_hit(self):
+        model = _make_model_class()
+        mgr = CategoryCacheManager(model)
+
+        with patch("common.cache_managers.cache") as mock_cache:
+            mock_cache.get.return_value = "Poor"
+            name = mgr.get_category_name_by_key("P")
+
+        self.assertEqual(name, "Poor")
+
+    def test_get_category_name_by_key_falls_back_to_all(self):
+        obj = self._make_obj("P", "Poor")
+        model = _make_model_class()
+        model.objects.all.return_value = [obj]
+        mgr = CategoryCacheManager(model)
+
+        # First get() call (individual key) misses; second (all:) also misses → build from DB
+        with patch("common.cache_managers.cache") as mock_cache:
+            mock_cache.get.return_value = None
+            mock_cache.set = MagicMock()
+            name = mgr.get_category_name_by_key("P")
+
+        self.assertEqual(name, "Poor")
+
+    def test_get_category_key_by_name_case_insensitive(self):
+        obj = self._make_obj("P", "Poor")
+        model = _make_model_class()
+        model.objects.all.return_value = [obj]
+        mgr = CategoryCacheManager(model)
+
+        with patch("common.cache_managers.cache") as mock_cache:
+            mock_cache.get.return_value = None
+            mock_cache.set = MagicMock()
+            key = mgr.get_category_key_by_name("POOR")
+
+        self.assertEqual(key, "P")
+
+    def test_get_category_key_by_name_returns_none_when_missing(self):
+        model = _make_model_class()
+        model.objects.all.return_value = []
+        mgr = CategoryCacheManager(model)
+
+        with patch("common.cache_managers.cache") as mock_cache:
+            mock_cache.get.return_value = None
+            mock_cache.set = MagicMock()
+            key = mgr.get_category_key_by_name("nonexistent")
+
+        self.assertIsNone(key)
+
+    def test_set_category_name_mapping_writes_both_directions(self):
+        model = _make_model_class()
+        mgr = CategoryCacheManager(model)
+
+        with patch("common.cache_managers.cache") as mock_cache:
+            mock_cache.set = MagicMock()
+            mgr.set_category_name_mapping("P", "Poor")
+
+        calls = mock_cache.set.call_args_list
+        set_keys = [c.args[0] for c in calls]
+        # Should have written name→key and key→name entries
+        self.assertEqual(len(calls), 2)
+        self.assertTrue(any("P" in k for k in set_keys))
+        self.assertTrue(any("poor" in k for k in set_keys))
+
+    def test_invalidate_category_deletes_correct_keys(self):
+        model = _make_model_class()
+        mgr = CategoryCacheManager(model)
+
+        with patch("common.cache_managers.cache") as mock_cache:
+            mock_cache.get.return_value = "Poor"  # name lookup
+            mock_cache.delete_many = MagicMock()
+            mgr.invalidate_category("P")
+
+        deleted = mock_cache.delete_many.call_args.args[0]
+        self.assertTrue(any("P" in k for k in deleted))
+
+
+# ---------------------------------------------------------------------------
+# GenericDataCacheManager
+# ---------------------------------------------------------------------------
+
+class GenericDataCacheManagerTests(TestCase):
+
+    def test_get_cache_keys_returns_data_key(self):
+        mgr = _make_generic_manager(prefix="myprefix")
+        keys = mgr.get_cache_keys()
+        self.assertIn("data", keys)
+        self.assertIn("myprefix", keys["data"])
+
+    def test_get_cached_data_module_cache_hit(self):
+        """If data is in module-level cache, Django cache is never consulted."""
+        mgr = _make_generic_manager(prefix="modcache")
+        mgr._module_cache["data"] = ["item1", "item2"]
+
+        with patch("common.cache_managers.cache") as mock_cache:
+            result = mgr.get_cached_data("data")
+
+        mock_cache.get.assert_not_called()
+        self.assertEqual(result, ["item1", "item2"])
+
+    def test_get_cached_data_redis_hit_populates_module_cache(self):
+        mgr = _make_generic_manager(prefix="rediscache")
+
+        with patch("common.cache_managers.cache") as mock_cache:
+            mock_cache.get.return_value = ["redis_item"]
+            mock_cache.set = MagicMock()
+            result = mgr.get_cached_data("data")
+
+        self.assertEqual(result, ["redis_item"])
+        self.assertEqual(mgr._module_cache.get("data"), ["redis_item"])
+
+    def test_get_cached_data_miss_calls_builder_and_caches(self):
+        builder = MagicMock(return_value={"data": ["fresh"]})
+        mgr = _make_generic_manager(prefix="dbmiss", builder=builder)
+
+        with patch("common.cache_managers.cache") as mock_cache:
+            mock_cache.get.return_value = None
+            mock_cache.set = MagicMock()
+            result = mgr.get_cached_data("data")
+
+        builder.assert_called_once()
+        mock_cache.set.assert_called_once()
+        self.assertEqual(result, ["fresh"])
+
+    def test_get_cached_data_invalid_key_returns_none(self):
+        mgr = _make_generic_manager()
+        result = mgr.get_cached_data("this_key_does_not_exist")
+        self.assertIsNone(result)
+
+    def test_get_cached_data_programming_error_returns_none(self):
+        from django.db.utils import ProgrammingError
+        builder = MagicMock(side_effect=ProgrammingError("table missing"))
+        mgr = _make_generic_manager(prefix="dberr", builder=builder)
+
+        with patch("common.cache_managers.cache") as mock_cache:
+            mock_cache.get.return_value = None
+            result = mgr.get_cached_data("data")
+
+        self.assertIsNone(result)
+
+    def test_get_cached_data_generic_exception_returns_none(self):
+        builder = MagicMock(side_effect=RuntimeError("unexpected"))
+        mgr = _make_generic_manager(prefix="unexpecterr", builder=builder)
+
+        with patch("common.cache_managers.cache") as mock_cache:
+            mock_cache.get.return_value = None
+            result = mgr.get_cached_data("data")
+
+        self.assertIsNone(result)
+
+    def test_invalidate_cache_clears_both_levels(self):
+        mgr = _make_generic_manager(prefix="inv_test")
+        mgr._module_cache["data"] = ["stale"]
+
+        with patch("common.cache_managers.cache") as mock_cache:
+            mock_cache.delete_many = MagicMock()
+            mgr.invalidate_cache("test")
+
+        mock_cache.delete_many.assert_called_once()
+        self.assertEqual(mgr._module_cache, {})
+
+    def test_get_cache_stats_keys(self):
+        mgr = _make_generic_manager(prefix="stats_test", timeout=120)
+
+        with patch("common.cache_managers.cache") as mock_cache:
+            mock_cache.get_many.return_value = {}
+            stats = mgr.get_cache_stats()
+
+        for key in ("cache_prefix", "redis_keys", "redis_keys_count",
+                    "module_cache_count", "cache_timeout", "timestamp"):
+            self.assertIn(key, stats)
+
+        self.assertEqual(stats["cache_prefix"], "stats_test")
+        self.assertEqual(stats["cache_timeout"], 120)
+
+
+# ---------------------------------------------------------------------------
+# FormChoicesCacheManager
+# ---------------------------------------------------------------------------
+
+class FormChoicesCacheManagerTests(TestCase):
+
+    def _make_manager(self, choice_data=None, prefix="form_test"):
+        """Return a FormChoicesCacheManager with mocked model."""
+        model = _make_model_class()
+        choice_data = choice_data or [{"color": "red"}, {"color": "blue"}]
+        model.objects.filter.return_value.values.return_value = choice_data
+        return FormChoicesCacheManager(
+            model_class=model,
+            choice_field="color",
+            cache_prefix=prefix,
+        )
+
+    def test_get_form_choices_returns_list(self):
+        mgr = self._make_manager()
+
+        with patch("common.cache_managers.cache") as mock_cache:
+            mock_cache.get.return_value = None
+            mock_cache.set = MagicMock()
+            choices = mgr.get_form_choices()
+
+        self.assertIsInstance(choices, list)
+
+    def test_get_queryset_json_returns_json_string(self):
+        mgr = self._make_manager()
+
+        with patch("common.cache_managers.cache") as mock_cache:
+            mock_cache.get.return_value = None
+            mock_cache.set = MagicMock()
+            qs_json = mgr.get_queryset_json()
+
+        # Should be valid JSON
+        parsed = json.loads(qs_json)
+        self.assertIsInstance(parsed, list)
+
+    def test_get_choices_and_queryset_returns_tuple(self):
+        mgr = self._make_manager()
+
+        with patch("common.cache_managers.cache") as mock_cache:
+            mock_cache.get.return_value = None
+            mock_cache.set = MagicMock()
+            choices, qs_json = mgr.get_choices_and_queryset()
+
+        self.assertIsInstance(choices, list)
+        self.assertIsInstance(qs_json, str)
+
+    def test_build_form_choices_data_structure(self):
+        mgr = self._make_manager(choice_data=[{"color": "red"}])
+        result = mgr._build_form_choices_data()
+        self.assertIn("choices", result)
+        self.assertIn("queryset", result)
+        # choices should be list of (value, display) tuples
+        choices = result["choices"]
+        self.assertEqual(len(choices), 1)
+        value, display = choices[0]
+        self.assertEqual(value, "red")
+
+    def test_build_form_choices_handles_attribute_error(self):
+        """Attribute/value errors during build return empty defaults."""
+        model = _make_model_class()
+        model.objects.filter.side_effect = AttributeError("no field")
+        mgr = FormChoicesCacheManager(
+            model_class=model,
+            choice_field="color",
+            cache_prefix="err_test",
+        )
+        result = mgr._build_form_choices_data()
+        self.assertEqual(result["choices"], [])
+        self.assertEqual(result["queryset"], "[]")
+
+    def test_get_cache_keys_has_choices_and_queryset(self):
+        mgr = self._make_manager()
+        keys = mgr.get_cache_keys()
+        self.assertIn("choices", keys)
+        self.assertIn("queryset", keys)
+
+
+# ---------------------------------------------------------------------------
+# Factory functions
+# ---------------------------------------------------------------------------
+
+class FactoryFunctionTests(TestCase):
+
+    def test_create_form_choices_manager_returns_instance(self):
+        from common.cache_managers import cache_registry
+        model = _make_model_class("FactoryModel")
+        model.objects.filter.return_value.values.return_value = []
+
+        mgr = create_form_choices_manager(
+            model_class=model,
+            choice_field="name",
+            cache_prefix="factory_choices_test",
+        )
+
+        self.assertIsInstance(mgr, FormChoicesCacheManager)
+        self.assertIsNotNone(cache_registry.get("factory_choices_test"))
+
+    def test_create_category_manager_returns_instance(self):
+        from common.cache_managers import cache_registry
+        model = _make_model_class("FactoryCatModel")
+        model.objects.all.return_value = []
+
+        mgr = create_category_manager(model_class=model)
+
+        self.assertIsInstance(mgr, CategoryCacheManager)
+        self.assertIsNotNone(cache_registry.get("FactoryCatModel_categories"))

--- a/common/tests/test_metrics.py
+++ b/common/tests/test_metrics.py
@@ -17,16 +17,14 @@ Covers:
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
-
 from django.test import TestCase
 
 from common.metrics import metrics
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _counter_value(counter, *label_values):
     """Read the current value of a labelled prometheus Counter."""
@@ -42,22 +40,26 @@ def _histogram_count(histogram, *label_values):
 # increment_cache
 # ---------------------------------------------------------------------------
 
+
 class IncrementCacheTests(TestCase):
 
     def test_hit_increments_cache_hits_counter(self):
         from common.metrics import CACHE_HITS
+
         before = _counter_value(CACHE_HITS, "test_prefix_hit")
         metrics.increment_cache("test_prefix_hit", "hit")
         self.assertEqual(_counter_value(CACHE_HITS, "test_prefix_hit"), before + 1)
 
     def test_miss_increments_cache_misses_counter(self):
         from common.metrics import CACHE_MISSES
+
         before = _counter_value(CACHE_MISSES, "test_prefix_miss")
         metrics.increment_cache("test_prefix_miss", "miss")
         self.assertEqual(_counter_value(CACHE_MISSES, "test_prefix_miss"), before + 1)
 
     def test_invalidated_increments_invalidations_counter(self):
         from common.metrics import CACHE_INVALIDATIONS
+
         before = _counter_value(CACHE_INVALIDATIONS, "test_prefix_inv", "signal")
         metrics.increment_cache("test_prefix_inv", "invalidated", reason="signal")
         self.assertEqual(
@@ -67,7 +69,10 @@ class IncrementCacheTests(TestCase):
 
     def test_invalidated_without_reason_uses_unspecified(self):
         from common.metrics import CACHE_INVALIDATIONS
-        before = _counter_value(CACHE_INVALIDATIONS, "test_prefix_noreason", "unspecified")
+
+        before = _counter_value(
+            CACHE_INVALIDATIONS, "test_prefix_noreason", "unspecified"
+        )
         metrics.increment_cache("test_prefix_noreason", "invalidated")
         self.assertEqual(
             _counter_value(CACHE_INVALIDATIONS, "test_prefix_noreason", "unspecified"),
@@ -76,7 +81,10 @@ class IncrementCacheTests(TestCase):
 
     def test_invalidated_empty_reason_uses_unspecified(self):
         from common.metrics import CACHE_INVALIDATIONS
-        before = _counter_value(CACHE_INVALIDATIONS, "test_prefix_empty_r", "unspecified")
+
+        before = _counter_value(
+            CACHE_INVALIDATIONS, "test_prefix_empty_r", "unspecified"
+        )
         metrics.increment_cache("test_prefix_empty_r", "invalidated", reason="   ")
         self.assertEqual(
             _counter_value(CACHE_INVALIDATIONS, "test_prefix_empty_r", "unspecified"),
@@ -94,11 +102,13 @@ class IncrementCacheTests(TestCase):
 # time_cache_operation
 # ---------------------------------------------------------------------------
 
+
 class TimeCacheOperationTests(TestCase):
 
     def test_context_manager_exits_without_exception(self):
         """Should not raise and should record an observation."""
         from common.metrics import CACHE_OP_SECONDS
+
         before = CACHE_OP_SECONDS.labels("op_prefix", "read")._sum.get()
         with metrics.time_cache_operation("op_prefix", "read"):
             pass  # simulate fast operation
@@ -118,10 +128,12 @@ class TimeCacheOperationTests(TestCase):
 # time_database_query
 # ---------------------------------------------------------------------------
 
+
 class TimeDatabaseQueryTests(TestCase):
 
     def test_success_path_records_observation(self):
         from common.metrics import DB_QUERY_SECONDS
+
         before = DB_QUERY_SECONDS.labels("db_prefix", "success")._sum.get()
         with metrics.time_database_query("db_prefix"):
             pass
@@ -131,6 +143,7 @@ class TimeDatabaseQueryTests(TestCase):
 
     def test_exception_path_labels_error_and_reraises(self):
         from common.metrics import DB_QUERY_SECONDS
+
         before = DB_QUERY_SECONDS.labels("db_prefix_err", "error")._sum.get()
         with self.assertRaises(ValueError):
             with metrics.time_database_query("db_prefix_err"):
@@ -144,10 +157,12 @@ class TimeDatabaseQueryTests(TestCase):
 # record_database_query_time
 # ---------------------------------------------------------------------------
 
+
 class RecordDatabaseQueryTimeTests(TestCase):
 
     def test_success_status_records_observation(self):
         from common.metrics import DB_QUERY_SECONDS
+
         before = DB_QUERY_SECONDS.labels("manual_prefix", "success")._sum.get()
         metrics.record_database_query_time("manual_prefix", 0.042, "success")
         after = DB_QUERY_SECONDS.labels("manual_prefix", "success")._sum.get()
@@ -155,6 +170,7 @@ class RecordDatabaseQueryTimeTests(TestCase):
 
     def test_error_status_records_observation(self):
         from common.metrics import DB_QUERY_SECONDS
+
         before = DB_QUERY_SECONDS.labels("manual_prefix_e", "error")._sum.get()
         metrics.record_database_query_time("manual_prefix_e", 0.1, "error")
         after = DB_QUERY_SECONDS.labels("manual_prefix_e", "error")._sum.get()
@@ -162,6 +178,7 @@ class RecordDatabaseQueryTimeTests(TestCase):
 
     def test_invalid_status_normalised_to_success(self):
         from common.metrics import DB_QUERY_SECONDS
+
         before = DB_QUERY_SECONDS.labels("manual_prefix_bad", "success")._sum.get()
         metrics.record_database_query_time("manual_prefix_bad", 0.01, "unknown_status")
         after = DB_QUERY_SECONDS.labels("manual_prefix_bad", "success")._sum.get()
@@ -169,6 +186,7 @@ class RecordDatabaseQueryTimeTests(TestCase):
 
     def test_none_status_normalised_to_success(self):
         from common.metrics import DB_QUERY_SECONDS
+
         before = DB_QUERY_SECONDS.labels("manual_prefix_none", "success")._sum.get()
         metrics.record_database_query_time("manual_prefix_none", 0.005, None)
         after = DB_QUERY_SECONDS.labels("manual_prefix_none", "success")._sum.get()
@@ -179,10 +197,12 @@ class RecordDatabaseQueryTimeTests(TestCase):
 # time_random_insult_stage
 # ---------------------------------------------------------------------------
 
+
 class TimeRandomInsultStageTests(TestCase):
 
     def test_context_manager_exits_cleanly(self):
         from common.metrics import RANDOM_INSULT_STAGE_SECONDS
+
         before = RANDOM_INSULT_STAGE_SECONDS.labels("queryset_build")._sum.get()
         with metrics.time_random_insult_stage("queryset_build"):
             pass
@@ -200,12 +220,14 @@ class TimeRandomInsultStageTests(TestCase):
 # sql_instrumentation
 # ---------------------------------------------------------------------------
 
+
 class SqlInstrumentationTests(TestCase):
     databases = ["default"]
 
     def test_counts_queries_executed_inside_block(self):
         """Each SQL statement issued inside the block increments query_count."""
         from django.contrib.auth import get_user_model
+
         User = get_user_model()
 
         with metrics.sql_instrumentation() as stats:
@@ -215,6 +237,7 @@ class SqlInstrumentationTests(TestCase):
 
     def test_total_ms_is_positive_after_query(self):
         from django.contrib.auth import get_user_model
+
         User = get_user_model()
 
         with metrics.sql_instrumentation() as stats:
@@ -234,6 +257,7 @@ class SqlInstrumentationTests(TestCase):
     def test_slowest_ms_tracks_max(self):
         """slowest_ms should reflect the maximum single-query duration."""
         from django.contrib.auth import get_user_model
+
         User = get_user_model()
 
         with metrics.sql_instrumentation() as stats:
@@ -248,10 +272,12 @@ class SqlInstrumentationTests(TestCase):
 # record_random_insult_request / record_random_insult_empty
 # ---------------------------------------------------------------------------
 
+
 class RecordRandomInsultRequestTests(TestCase):
 
     def test_increments_request_counter(self):
         from common.metrics import RANDOM_INSULT_REQUESTS
+
         before = _counter_value(RANDOM_INSULT_REQUESTS, "200", "false", "false")
         metrics.record_random_insult_request(
             status="200",
@@ -266,6 +292,7 @@ class RecordRandomInsultRequestTests(TestCase):
 
     def test_increments_db_queries_counter_by_count(self):
         from common.metrics import RANDOM_INSULT_DB_QUERIES
+
         before = RANDOM_INSULT_DB_QUERIES._value.get()
         metrics.record_random_insult_request(
             status="200",
@@ -277,6 +304,7 @@ class RecordRandomInsultRequestTests(TestCase):
 
     def test_record_random_insult_empty_increments_counter(self):
         from common.metrics import RANDOM_INSULT_QUERYSET_EMPTY
+
         before = RANDOM_INSULT_QUERYSET_EMPTY._value.get()
         metrics.record_random_insult_empty()
         self.assertEqual(RANDOM_INSULT_QUERYSET_EMPTY._value.get(), before + 1)
@@ -286,16 +314,21 @@ class RecordRandomInsultRequestTests(TestCase):
 # increment_endpoint_cache
 # ---------------------------------------------------------------------------
 
+
 class IncrementEndpointCacheTests(TestCase):
 
     def test_hit_increments_endpoint_cache_hits(self):
         from common.metrics import ENDPOINT_CACHE_HITS
+
         before = _counter_value(ENDPOINT_CACHE_HITS, "/api/insults/")
         metrics.increment_endpoint_cache("/api/insults/", "hit")
-        self.assertEqual(_counter_value(ENDPOINT_CACHE_HITS, "/api/insults/"), before + 1)
+        self.assertEqual(
+            _counter_value(ENDPOINT_CACHE_HITS, "/api/insults/"), before + 1
+        )
 
     def test_miss_increments_endpoint_cache_misses(self):
         from common.metrics import ENDPOINT_CACHE_MISSES
+
         before = _counter_value(ENDPOINT_CACHE_MISSES, "/api/insults/random/")
         metrics.increment_endpoint_cache("/api/insults/random/", "miss")
         self.assertEqual(

--- a/common/tests/test_metrics.py
+++ b/common/tests/test_metrics.py
@@ -1,0 +1,309 @@
+"""
+Tests for common.metrics._MetricsFacade (exposed as the module-level `metrics` singleton).
+
+Covers:
+- increment_cache: hit / miss / invalidated (with and without reason) / unknown event raises
+- time_cache_operation: context manager records histogram and exits cleanly
+- time_cache_operation: exception propagates and re-raises
+- time_database_query: success path labels status="success"
+- time_database_query: exception path labels status="error" and re-raises
+- record_database_query_time: valid statuses accepted; invalid normalised to "success"
+- time_random_insult_stage: context manager exits cleanly
+- sql_instrumentation: counts queries and tracks timing
+- record_random_insult_request: increments RANDOM_INSULT_REQUESTS counter
+- record_random_insult_empty: increments RANDOM_INSULT_QUERYSET_EMPTY counter
+- increment_endpoint_cache: hit / miss / unknown raises
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from common.metrics import metrics
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _counter_value(counter, *label_values):
+    """Read the current value of a labelled prometheus Counter."""
+    return counter.labels(*label_values)._value.get()
+
+
+def _histogram_count(histogram, *label_values):
+    """Read the observation count of a labelled prometheus Histogram."""
+    return histogram.labels(*label_values)._sum.get()
+
+
+# ---------------------------------------------------------------------------
+# increment_cache
+# ---------------------------------------------------------------------------
+
+class IncrementCacheTests(TestCase):
+
+    def test_hit_increments_cache_hits_counter(self):
+        from common.metrics import CACHE_HITS
+        before = _counter_value(CACHE_HITS, "test_prefix_hit")
+        metrics.increment_cache("test_prefix_hit", "hit")
+        self.assertEqual(_counter_value(CACHE_HITS, "test_prefix_hit"), before + 1)
+
+    def test_miss_increments_cache_misses_counter(self):
+        from common.metrics import CACHE_MISSES
+        before = _counter_value(CACHE_MISSES, "test_prefix_miss")
+        metrics.increment_cache("test_prefix_miss", "miss")
+        self.assertEqual(_counter_value(CACHE_MISSES, "test_prefix_miss"), before + 1)
+
+    def test_invalidated_increments_invalidations_counter(self):
+        from common.metrics import CACHE_INVALIDATIONS
+        before = _counter_value(CACHE_INVALIDATIONS, "test_prefix_inv", "signal")
+        metrics.increment_cache("test_prefix_inv", "invalidated", reason="signal")
+        self.assertEqual(
+            _counter_value(CACHE_INVALIDATIONS, "test_prefix_inv", "signal"),
+            before + 1,
+        )
+
+    def test_invalidated_without_reason_uses_unspecified(self):
+        from common.metrics import CACHE_INVALIDATIONS
+        before = _counter_value(CACHE_INVALIDATIONS, "test_prefix_noreason", "unspecified")
+        metrics.increment_cache("test_prefix_noreason", "invalidated")
+        self.assertEqual(
+            _counter_value(CACHE_INVALIDATIONS, "test_prefix_noreason", "unspecified"),
+            before + 1,
+        )
+
+    def test_invalidated_empty_reason_uses_unspecified(self):
+        from common.metrics import CACHE_INVALIDATIONS
+        before = _counter_value(CACHE_INVALIDATIONS, "test_prefix_empty_r", "unspecified")
+        metrics.increment_cache("test_prefix_empty_r", "invalidated", reason="   ")
+        self.assertEqual(
+            _counter_value(CACHE_INVALIDATIONS, "test_prefix_empty_r", "unspecified"),
+            before + 1,
+        )
+
+    def test_unknown_event_raises_value_error(self):
+        with self.assertRaises(ValueError) as ctx:
+            metrics.increment_cache("any", "bogus_event")
+        self.assertIn("bogus_event", str(ctx.exception))
+        self.assertIn("hit|miss|invalidated", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# time_cache_operation
+# ---------------------------------------------------------------------------
+
+class TimeCacheOperationTests(TestCase):
+
+    def test_context_manager_exits_without_exception(self):
+        """Should not raise and should record an observation."""
+        from common.metrics import CACHE_OP_SECONDS
+        before = CACHE_OP_SECONDS.labels("op_prefix", "read")._sum.get()
+        with metrics.time_cache_operation("op_prefix", "read"):
+            pass  # simulate fast operation
+        # At least one observation was added
+        self.assertGreaterEqual(
+            CACHE_OP_SECONDS.labels("op_prefix", "read")._sum.get(), before
+        )
+
+    def test_exception_propagates(self):
+        """Exceptions inside the block must not be swallowed."""
+        with self.assertRaises(RuntimeError):
+            with metrics.time_cache_operation("op_prefix", "write"):
+                raise RuntimeError("boom")
+
+
+# ---------------------------------------------------------------------------
+# time_database_query
+# ---------------------------------------------------------------------------
+
+class TimeDatabaseQueryTests(TestCase):
+
+    def test_success_path_records_observation(self):
+        from common.metrics import DB_QUERY_SECONDS
+        before = DB_QUERY_SECONDS.labels("db_prefix", "success")._sum.get()
+        with metrics.time_database_query("db_prefix"):
+            pass
+        self.assertGreaterEqual(
+            DB_QUERY_SECONDS.labels("db_prefix", "success")._sum.get(), before
+        )
+
+    def test_exception_path_labels_error_and_reraises(self):
+        from common.metrics import DB_QUERY_SECONDS
+        before = DB_QUERY_SECONDS.labels("db_prefix_err", "error")._sum.get()
+        with self.assertRaises(ValueError):
+            with metrics.time_database_query("db_prefix_err"):
+                raise ValueError("db exploded")
+        self.assertGreaterEqual(
+            DB_QUERY_SECONDS.labels("db_prefix_err", "error")._sum.get(), before
+        )
+
+
+# ---------------------------------------------------------------------------
+# record_database_query_time
+# ---------------------------------------------------------------------------
+
+class RecordDatabaseQueryTimeTests(TestCase):
+
+    def test_success_status_records_observation(self):
+        from common.metrics import DB_QUERY_SECONDS
+        before = DB_QUERY_SECONDS.labels("manual_prefix", "success")._sum.get()
+        metrics.record_database_query_time("manual_prefix", 0.042, "success")
+        after = DB_QUERY_SECONDS.labels("manual_prefix", "success")._sum.get()
+        self.assertAlmostEqual(after - before, 0.042, places=5)
+
+    def test_error_status_records_observation(self):
+        from common.metrics import DB_QUERY_SECONDS
+        before = DB_QUERY_SECONDS.labels("manual_prefix_e", "error")._sum.get()
+        metrics.record_database_query_time("manual_prefix_e", 0.1, "error")
+        after = DB_QUERY_SECONDS.labels("manual_prefix_e", "error")._sum.get()
+        self.assertAlmostEqual(after - before, 0.1, places=5)
+
+    def test_invalid_status_normalised_to_success(self):
+        from common.metrics import DB_QUERY_SECONDS
+        before = DB_QUERY_SECONDS.labels("manual_prefix_bad", "success")._sum.get()
+        metrics.record_database_query_time("manual_prefix_bad", 0.01, "unknown_status")
+        after = DB_QUERY_SECONDS.labels("manual_prefix_bad", "success")._sum.get()
+        self.assertAlmostEqual(after - before, 0.01, places=5)
+
+    def test_none_status_normalised_to_success(self):
+        from common.metrics import DB_QUERY_SECONDS
+        before = DB_QUERY_SECONDS.labels("manual_prefix_none", "success")._sum.get()
+        metrics.record_database_query_time("manual_prefix_none", 0.005, None)
+        after = DB_QUERY_SECONDS.labels("manual_prefix_none", "success")._sum.get()
+        self.assertAlmostEqual(after - before, 0.005, places=5)
+
+
+# ---------------------------------------------------------------------------
+# time_random_insult_stage
+# ---------------------------------------------------------------------------
+
+class TimeRandomInsultStageTests(TestCase):
+
+    def test_context_manager_exits_cleanly(self):
+        from common.metrics import RANDOM_INSULT_STAGE_SECONDS
+        before = RANDOM_INSULT_STAGE_SECONDS.labels("queryset_build")._sum.get()
+        with metrics.time_random_insult_stage("queryset_build"):
+            pass
+        self.assertGreaterEqual(
+            RANDOM_INSULT_STAGE_SECONDS.labels("queryset_build")._sum.get(), before
+        )
+
+    def test_exception_propagates(self):
+        with self.assertRaises(KeyError):
+            with metrics.time_random_insult_stage("serialization"):
+                raise KeyError("missing")
+
+
+# ---------------------------------------------------------------------------
+# sql_instrumentation
+# ---------------------------------------------------------------------------
+
+class SqlInstrumentationTests(TestCase):
+    databases = ["default"]
+
+    def test_counts_queries_executed_inside_block(self):
+        """Each SQL statement issued inside the block increments query_count."""
+        from django.contrib.auth import get_user_model
+        User = get_user_model()
+
+        with metrics.sql_instrumentation() as stats:
+            list(User.objects.all())  # forces at least one SQL hit
+
+        self.assertGreaterEqual(stats["query_count"], 1)
+
+    def test_total_ms_is_positive_after_query(self):
+        from django.contrib.auth import get_user_model
+        User = get_user_model()
+
+        with metrics.sql_instrumentation() as stats:
+            list(User.objects.all())
+
+        self.assertGreater(stats["total_ms"], 0)
+
+    def test_slowest_ms_gte_zero_with_no_queries(self):
+        """Block with no SQL → all stats remain at zero."""
+        with metrics.sql_instrumentation() as stats:
+            pass
+
+        self.assertEqual(stats["query_count"], 0)
+        self.assertEqual(stats["total_ms"], 0.0)
+        self.assertEqual(stats["slowest_ms"], 0.0)
+
+    def test_slowest_ms_tracks_max(self):
+        """slowest_ms should reflect the maximum single-query duration."""
+        from django.contrib.auth import get_user_model
+        User = get_user_model()
+
+        with metrics.sql_instrumentation() as stats:
+            list(User.objects.all())
+            list(User.objects.all())
+
+        self.assertGreaterEqual(stats["slowest_ms"], 0)
+        self.assertLessEqual(stats["slowest_ms"], stats["total_ms"])
+
+
+# ---------------------------------------------------------------------------
+# record_random_insult_request / record_random_insult_empty
+# ---------------------------------------------------------------------------
+
+class RecordRandomInsultRequestTests(TestCase):
+
+    def test_increments_request_counter(self):
+        from common.metrics import RANDOM_INSULT_REQUESTS
+        before = _counter_value(RANDOM_INSULT_REQUESTS, "200", "false", "false")
+        metrics.record_random_insult_request(
+            status="200",
+            category_filtered=False,
+            nsfw_filtered=False,
+            db_query_count=3,
+        )
+        self.assertEqual(
+            _counter_value(RANDOM_INSULT_REQUESTS, "200", "false", "false"),
+            before + 1,
+        )
+
+    def test_increments_db_queries_counter_by_count(self):
+        from common.metrics import RANDOM_INSULT_DB_QUERIES
+        before = RANDOM_INSULT_DB_QUERIES._value.get()
+        metrics.record_random_insult_request(
+            status="200",
+            category_filtered=True,
+            nsfw_filtered=True,
+            db_query_count=5,
+        )
+        self.assertEqual(RANDOM_INSULT_DB_QUERIES._value.get(), before + 5)
+
+    def test_record_random_insult_empty_increments_counter(self):
+        from common.metrics import RANDOM_INSULT_QUERYSET_EMPTY
+        before = RANDOM_INSULT_QUERYSET_EMPTY._value.get()
+        metrics.record_random_insult_empty()
+        self.assertEqual(RANDOM_INSULT_QUERYSET_EMPTY._value.get(), before + 1)
+
+
+# ---------------------------------------------------------------------------
+# increment_endpoint_cache
+# ---------------------------------------------------------------------------
+
+class IncrementEndpointCacheTests(TestCase):
+
+    def test_hit_increments_endpoint_cache_hits(self):
+        from common.metrics import ENDPOINT_CACHE_HITS
+        before = _counter_value(ENDPOINT_CACHE_HITS, "/api/insults/")
+        metrics.increment_endpoint_cache("/api/insults/", "hit")
+        self.assertEqual(_counter_value(ENDPOINT_CACHE_HITS, "/api/insults/"), before + 1)
+
+    def test_miss_increments_endpoint_cache_misses(self):
+        from common.metrics import ENDPOINT_CACHE_MISSES
+        before = _counter_value(ENDPOINT_CACHE_MISSES, "/api/insults/random/")
+        metrics.increment_endpoint_cache("/api/insults/random/", "miss")
+        self.assertEqual(
+            _counter_value(ENDPOINT_CACHE_MISSES, "/api/insults/random/"), before + 1
+        )
+
+    def test_unknown_event_raises_value_error(self):
+        with self.assertRaises(ValueError) as ctx:
+            metrics.increment_endpoint_cache("/api/test/", "stale")
+        self.assertIn("stale", str(ctx.exception))
+        self.assertIn("hit|miss", str(ctx.exception))

--- a/common/tests/test_middleware.py
+++ b/common/tests/test_middleware.py
@@ -1,0 +1,129 @@
+"""
+Tests for common.middleware.RequestIDMiddleware.
+
+Covers:
+- Existing X-Request-ID header is propagated (not overwritten)
+- Missing header causes a fresh UUID4 to be generated
+- Generated ID is a valid UUID (won't collide across requests)
+- request.request_id is attached to the request object
+- X-Request-ID is written onto the response
+- Loguru context is active during request processing (contextualise smoke-test)
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+from django.test import RequestFactory, TestCase
+
+from common.middleware import RequestIDMiddleware
+
+
+def _make_middleware(response=None):
+    """Return a middleware instance whose inner callable returns *response*."""
+    if response is None:
+        response = MagicMock()
+        response.__setitem__ = MagicMock()  # support response["X-Request-ID"] = ...
+    get_response = MagicMock(return_value=response)
+    mw = RequestIDMiddleware(get_response)
+    return mw, get_response, response
+
+
+class RequestIDMiddlewarePropagationTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_existing_header_is_preserved(self):
+        """Client-supplied X-Request-ID must not be replaced."""
+        client_id = "my-client-request-id-123"
+        request = self.factory.get("/", HTTP_X_REQUEST_ID=client_id)
+        mw, get_response, response = _make_middleware()
+
+        mw(request)
+
+        self.assertEqual(request.request_id, client_id)
+
+    def test_missing_header_generates_uuid(self):
+        """No X-Request-ID header → middleware generates one."""
+        request = self.factory.get("/")
+        mw, get_response, response = _make_middleware()
+
+        mw(request)
+
+        generated_id = request.request_id
+        self.assertIsNotNone(generated_id)
+        # Must be parseable as a UUID
+        parsed = uuid.UUID(generated_id)
+        self.assertEqual(str(parsed), generated_id)
+
+    def test_generated_ids_are_unique_per_request(self):
+        """Two requests without a header must receive different IDs."""
+        mw, _, _ = _make_middleware()
+        r1 = self.factory.get("/")
+        r2 = self.factory.get("/")
+
+        mw(r1)
+        # Need a fresh middleware instance (or the same — both fine since uuid4 is random)
+        mw2, _, _ = _make_middleware()
+        mw2(r2)
+
+        self.assertNotEqual(r1.request_id, r2.request_id)
+
+    def test_response_header_set_to_propagated_id(self):
+        """X-Request-ID on the response must equal the inbound header value."""
+        client_id = "trace-abc-789"
+        request = self.factory.get("/", HTTP_X_REQUEST_ID=client_id)
+        response = {}
+        get_response = MagicMock(return_value=response)
+        mw = RequestIDMiddleware(get_response)
+
+        mw(request)
+
+        self.assertEqual(response["X-Request-ID"], client_id)
+
+    def test_response_header_set_to_generated_id(self):
+        """X-Request-ID on the response must equal the generated ID when none supplied."""
+        request = self.factory.get("/")
+        response = {}
+        get_response = MagicMock(return_value=response)
+        mw = RequestIDMiddleware(get_response)
+
+        mw(request)
+
+        self.assertEqual(response["X-Request-ID"], request.request_id)
+
+    def test_get_response_called_exactly_once(self):
+        """The inner callable must be called exactly once per request."""
+        request = self.factory.get("/")
+        mw, get_response, _ = _make_middleware()
+
+        mw(request)
+
+        get_response.assert_called_once_with(request)
+
+
+class RequestIDMiddlewareLogContextTests(TestCase):
+    """Smoke-test that Loguru contextualise is entered during request handling."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_loguru_contextualize_called_with_request_id(self):
+        """logger.contextualize must be entered with the request_id during the call."""
+        request = self.factory.get("/", HTTP_X_REQUEST_ID="ctx-test-id")
+        response = {}
+        get_response = MagicMock(return_value=response)
+        mw = RequestIDMiddleware(get_response)
+
+        with patch("common.middleware.logger") as mock_logger:
+            ctx_manager = MagicMock()
+            ctx_manager.__enter__ = MagicMock(return_value=None)
+            ctx_manager.__exit__ = MagicMock(return_value=False)
+            mock_logger.contextualize.return_value = ctx_manager
+
+            mw(request)
+
+            mock_logger.contextualize.assert_called_once_with(request_id="ctx-test-id")
+            ctx_manager.__enter__.assert_called_once()
+            ctx_manager.__exit__.assert_called_once()

--- a/core/settings.py
+++ b/core/settings.py
@@ -797,16 +797,14 @@ class Production(Base):
     ALLOWED_HOSTS = values.ListValue(
         environ=True, environ_prefix=None, environ_name="ALLOWED_HOSTS"
     )
-    # IPs permitted to scrape /metrics.
-    # Includes the native Prometheus host AND the Docker edge-network gateway
-    # (172.28.0.1) because when Prometheus accesses the published container port
-    # Docker NAT rewrites the source to the bridge gateway, not the real host IP.
-    # Override via PROMETHEUS_ALLOWED_HOSTS in Doppler if either address changes.
-    PROMETHEUS_ALLOWED_HOSTS = values.ListValue(
-        ["165.227.105.209", "172.28.0.1"],
+    # Secret token that Prometheus must send as "Authorization: Bearer <token>"
+    # when scraping /metrics.  Set METRICS_SCRAPE_TOKEN in Doppler.
+    # IP-based allowlists are no longer used — Docker NAT makes them unreliable.
+    METRICS_SCRAPE_TOKEN = values.Value(
+        "",
         environ=True,
         environ_prefix=None,
-        environ_name="PROMETHEUS_ALLOWED_HOSTS",
+        environ_name="METRICS_SCRAPE_TOKEN",
     )
     INSTALLED_APPS = values.ListValue(
         [

--- a/core/tests/test_metrics_view.py
+++ b/core/tests/test_metrics_view.py
@@ -42,16 +42,18 @@ class MetricsViewTokenAllowedTests(TestCase):
     def test_correct_bearer_token_returns_200(self):
         with patch(PROMETHEUS_200_PATCH) as mock_export:
             mock_export.return_value.status_code = 200
-            metrics_view(_request(f"Bearer {VALID_TOKEN}"))
+            response = metrics_view(_request(f"Bearer {VALID_TOKEN}"))
         mock_export.assert_called_once()
+        self.assertEqual(response.status_code, 200)
 
     @override_settings(METRICS_SCRAPE_TOKEN=VALID_TOKEN)
     def test_correct_token_with_surrounding_whitespace_is_accepted(self):
         """Prometheus may send a token with trailing newline from credentials_file."""
         with patch(PROMETHEUS_200_PATCH) as mock_export:
             mock_export.return_value.status_code = 200
-            metrics_view(_request(f"Bearer  {VALID_TOKEN}  "))
+            response = metrics_view(_request(f"Bearer  {VALID_TOKEN}  "))
         mock_export.assert_called_once()
+        self.assertEqual(response.status_code, 200)
 
 
 class MetricsViewTokenRejectedTests(TestCase):

--- a/core/tests/test_metrics_view.py
+++ b/core/tests/test_metrics_view.py
@@ -1,17 +1,20 @@
 """
-Tests for the /metrics endpoint IP allowlist enforced by metrics_view.
+Tests for the /metrics endpoint bearer-token auth enforced by metrics_view.
+
+Auth mechanism: Authorization: Bearer <METRICS_SCRAPE_TOKEN>
+Compared with hmac.compare_digest to prevent timing attacks.
 
 Covers:
-- Exact IP match (IPv4)
-- CIDR match (host inside subnet)
-- CIDR boundary (host just outside subnet is rejected)
-- Empty allowlist rejects everything
-- Missing PROMETHEUS_ALLOWED_HOSTS setting rejects everything
-- Malformed REMOTE_ADDR is rejected, not 500'd
-- Malformed entry in allowlist is skipped, not 500'd
-- IPv6 exact match
-- IPv6 CIDR match
-- 200 response delegates to django-prometheus (smoke-check body)
+- Correct token returns 200 and delegates to ExportToDjangoView
+- Wrong token is rejected (403)
+- Empty token in header is rejected
+- Missing Authorization header is rejected
+- Non-Bearer scheme (Basic, Token, etc.) is rejected
+- Malformed header (no space) is rejected
+- METRICS_SCRAPE_TOKEN unset in settings → always 403
+- METRICS_SCRAPE_TOKEN empty string in settings → always 403
+- Token comparison is case-sensitive
+- Surrounding whitespace in provided token is stripped before compare
 """
 
 from unittest.mock import patch
@@ -21,151 +24,99 @@ from django.test import RequestFactory, TestCase, override_settings
 from core.urls import metrics_view
 
 PROMETHEUS_200_PATCH = "core.urls.ExportToDjangoView"
+VALID_TOKEN = "super-secret-scrape-token-abc123"
 
 
-def _get(ip: str):
-    """Build a GET request with the given REMOTE_ADDR."""
+def _request(auth_header: str | None = None):
+    """Build a GET /metrics request with an optional Authorization header."""
     factory = RequestFactory()
-    request = factory.get("/metrics")
-    request.META["REMOTE_ADDR"] = ip
-    return request
+    kwargs = {}
+    if auth_header is not None:
+        kwargs["HTTP_AUTHORIZATION"] = auth_header
+    return factory.get("/metrics", **kwargs)
 
 
-class MetricsViewExactIPTests(TestCase):
-    ALLOWED = ["165.227.105.209", "172.28.0.1"]
+class MetricsViewTokenAllowedTests(TestCase):
 
-    @override_settings(PROMETHEUS_ALLOWED_HOSTS=ALLOWED)
-    def test_exact_ip_allowed(self):
+    @override_settings(METRICS_SCRAPE_TOKEN=VALID_TOKEN)
+    def test_correct_bearer_token_returns_200(self):
         with patch(PROMETHEUS_200_PATCH) as mock_export:
-            mock_export.return_value.__class__.__name__ = "HttpResponse"
             mock_export.return_value.status_code = 200
-            metrics_view(_get("165.227.105.209"))
+            metrics_view(_request(f"Bearer {VALID_TOKEN}"))
         mock_export.assert_called_once()
 
-    @override_settings(PROMETHEUS_ALLOWED_HOSTS=ALLOWED)
-    def test_second_exact_ip_allowed(self):
+    @override_settings(METRICS_SCRAPE_TOKEN=VALID_TOKEN)
+    def test_correct_token_with_surrounding_whitespace_is_accepted(self):
+        """Prometheus may send a token with trailing newline from credentials_file."""
         with patch(PROMETHEUS_200_PATCH) as mock_export:
             mock_export.return_value.status_code = 200
-            metrics_view(_get("172.28.0.1"))
+            metrics_view(_request(f"Bearer  {VALID_TOKEN}  "))
         mock_export.assert_called_once()
 
-    @override_settings(PROMETHEUS_ALLOWED_HOSTS=ALLOWED)
-    def test_unlisted_ip_forbidden(self):
-        response = metrics_view(_get("10.0.0.1"))
+
+class MetricsViewTokenRejectedTests(TestCase):
+
+    @override_settings(METRICS_SCRAPE_TOKEN=VALID_TOKEN)
+    def test_wrong_token_is_forbidden(self):
+        response = metrics_view(_request("Bearer wrong-token"))
         self.assertEqual(response.status_code, 403)
 
-    @override_settings(PROMETHEUS_ALLOWED_HOSTS=ALLOWED)
-    def test_similar_but_different_ip_forbidden(self):
-        # 165.227.105.210 differs by one octet from the allowed address
-        response = metrics_view(_get("165.227.105.210"))
+    @override_settings(METRICS_SCRAPE_TOKEN=VALID_TOKEN)
+    def test_empty_bearer_value_is_forbidden(self):
+        response = metrics_view(_request("Bearer "))
+        self.assertEqual(response.status_code, 403)
+
+    @override_settings(METRICS_SCRAPE_TOKEN=VALID_TOKEN)
+    def test_missing_authorization_header_is_forbidden(self):
+        response = metrics_view(_request())
+        self.assertEqual(response.status_code, 403)
+
+    @override_settings(METRICS_SCRAPE_TOKEN=VALID_TOKEN)
+    def test_basic_auth_scheme_is_rejected(self):
+        response = metrics_view(_request(f"Basic {VALID_TOKEN}"))
+        self.assertEqual(response.status_code, 403)
+
+    @override_settings(METRICS_SCRAPE_TOKEN=VALID_TOKEN)
+    def test_token_scheme_is_rejected(self):
+        response = metrics_view(_request(f"Token {VALID_TOKEN}"))
+        self.assertEqual(response.status_code, 403)
+
+    @override_settings(METRICS_SCRAPE_TOKEN=VALID_TOKEN)
+    def test_malformed_header_no_space_is_rejected(self):
+        """Header with no space between scheme and value (no Bearer prefix at all)."""
+        response = metrics_view(_request(VALID_TOKEN))
+        self.assertEqual(response.status_code, 403)
+
+    @override_settings(METRICS_SCRAPE_TOKEN=VALID_TOKEN)
+    def test_token_is_case_sensitive(self):
+        response = metrics_view(_request(f"Bearer {VALID_TOKEN.upper()}"))
+        self.assertEqual(response.status_code, 403)
+
+    @override_settings(METRICS_SCRAPE_TOKEN=VALID_TOKEN)
+    def test_partial_token_is_rejected(self):
+        response = metrics_view(_request(f"Bearer {VALID_TOKEN[:10]}"))
         self.assertEqual(response.status_code, 403)
 
 
-class MetricsViewCIDRTests(TestCase):
-    @override_settings(PROMETHEUS_ALLOWED_HOSTS=["172.19.0.0/24"])
-    def test_ip_inside_subnet_allowed(self):
-        with patch(PROMETHEUS_200_PATCH) as mock_export:
-            mock_export.return_value.status_code = 200
-            metrics_view(_get("172.19.0.10"))
-        mock_export.assert_called_once()
+class MetricsViewUnconfiguredTests(TestCase):
 
-    @override_settings(PROMETHEUS_ALLOWED_HOSTS=["172.19.0.0/24"])
-    def test_subnet_gateway_allowed(self):
-        with patch(PROMETHEUS_200_PATCH) as mock_export:
-            mock_export.return_value.status_code = 200
-            metrics_view(_get("172.19.0.1"))
-        mock_export.assert_called_once()
-
-    @override_settings(PROMETHEUS_ALLOWED_HOSTS=["172.19.0.0/24"])
-    def test_ip_outside_subnet_forbidden(self):
-        # 172.19.1.1 is in 172.19.1.0/24, not 172.19.0.0/24
-        response = metrics_view(_get("172.19.1.1"))
+    @override_settings(METRICS_SCRAPE_TOKEN="")
+    def test_empty_setting_forbids_all_requests(self):
+        """Empty token in settings means endpoint is locked down entirely."""
+        response = metrics_view(_request(f"Bearer {VALID_TOKEN}"))
         self.assertEqual(response.status_code, 403)
 
-    @override_settings(PROMETHEUS_ALLOWED_HOSTS=["172.19.0.0/24"])
-    def test_ip_in_adjacent_subnet_forbidden(self):
-        response = metrics_view(_get("172.20.0.1"))
-        self.assertEqual(response.status_code, 403)
-
-    @override_settings(PROMETHEUS_ALLOWED_HOSTS=["172.19.0.0/24", "165.227.105.209"])
-    def test_mixed_cidr_and_exact_ip_both_work(self):
-        with patch(PROMETHEUS_200_PATCH) as mock_export:
-            mock_export.return_value.status_code = 200
-            metrics_view(_get("172.19.0.50"))
-            metrics_view(_get("165.227.105.209"))
-        self.assertEqual(mock_export.call_count, 2)
-
-
-class MetricsViewEdgeCasesTests(TestCase):
-    @override_settings(PROMETHEUS_ALLOWED_HOSTS=[])
-    def test_empty_allowlist_forbids_all(self):
-        response = metrics_view(_get("165.227.105.209"))
-        self.assertEqual(response.status_code, 403)
-
-    def test_missing_setting_forbids_all(self):
-        # Simulate the setting not existing at all on the settings object
+    def test_missing_setting_forbids_all_requests(self):
+        """If METRICS_SCRAPE_TOKEN is absent from settings, always 403."""
         from django.conf import settings as django_settings
 
-        original = getattr(django_settings, "PROMETHEUS_ALLOWED_HOSTS", None)
-        if hasattr(django_settings, "PROMETHEUS_ALLOWED_HOSTS"):
-            delattr(django_settings, "PROMETHEUS_ALLOWED_HOSTS")
+        original = getattr(django_settings, "METRICS_SCRAPE_TOKEN", None)
+        had_attr = hasattr(django_settings, "METRICS_SCRAPE_TOKEN")
+        if had_attr:
+            delattr(django_settings, "METRICS_SCRAPE_TOKEN")
         try:
-            response = metrics_view(_get("165.227.105.209"))
+            response = metrics_view(_request(f"Bearer {VALID_TOKEN}"))
             self.assertEqual(response.status_code, 403)
         finally:
-            if original is not None:
-                django_settings.PROMETHEUS_ALLOWED_HOSTS = original
-
-    @override_settings(PROMETHEUS_ALLOWED_HOSTS=["165.227.105.209"])
-    def test_malformed_remote_addr_forbidden_not_500(self):
-        response = metrics_view(_get("not-an-ip"))
-        self.assertEqual(response.status_code, 403)
-
-    @override_settings(PROMETHEUS_ALLOWED_HOSTS=["165.227.105.209"])
-    def test_empty_remote_addr_forbidden(self):
-        factory = RequestFactory()
-        request = factory.get("/metrics")
-        request.META["REMOTE_ADDR"] = ""
-        response = metrics_view(request)
-        self.assertEqual(response.status_code, 403)
-
-    @override_settings(
-        PROMETHEUS_ALLOWED_HOSTS=["not-a-valid-entry", "165.227.105.209"]
-    )
-    def test_malformed_allowlist_entry_skipped(self):
-        # Bad entry is skipped; the valid entry still grants access
-        with patch(PROMETHEUS_200_PATCH) as mock_export:
-            mock_export.return_value.status_code = 200
-            metrics_view(_get("165.227.105.209"))
-        mock_export.assert_called_once()
-
-    @override_settings(PROMETHEUS_ALLOWED_HOSTS=["not-a-valid-entry"])
-    def test_only_malformed_allowlist_entry_forbids(self):
-        response = metrics_view(_get("165.227.105.209"))
-        self.assertEqual(response.status_code, 403)
-
-
-class MetricsViewIPv6Tests(TestCase):
-    @override_settings(PROMETHEUS_ALLOWED_HOSTS=["::1"])
-    def test_ipv6_loopback_exact_allowed(self):
-        with patch(PROMETHEUS_200_PATCH) as mock_export:
-            mock_export.return_value.status_code = 200
-            response = metrics_view(_get("::1"))
-        mock_export.assert_called_once()
-
-    @override_settings(PROMETHEUS_ALLOWED_HOSTS=["2001:db8::/32"])
-    def test_ipv6_cidr_match_allowed(self):
-        with patch(PROMETHEUS_200_PATCH) as mock_export:
-            mock_export.return_value.status_code = 200
-            response = metrics_view(_get("2001:db8::1"))
-        mock_export.assert_called_once()
-
-    @override_settings(PROMETHEUS_ALLOWED_HOSTS=["2001:db8::/32"])
-    def test_ipv6_outside_subnet_forbidden(self):
-        response = metrics_view(_get("2001:db9::1"))
-        self.assertEqual(response.status_code, 403)
-
-    @override_settings(PROMETHEUS_ALLOWED_HOSTS=["::1"])
-    def test_ipv4_rejected_when_only_ipv6_allowed(self):
-        response = metrics_view(_get("127.0.0.1"))
-        self.assertEqual(response.status_code, 403)
+            if had_attr and original is not None:
+                django_settings.METRICS_SCRAPE_TOKEN = original

--- a/core/urls.py
+++ b/core/urls.py
@@ -4,7 +4,7 @@ Root URL configuration for thedozens project.
 """
 
 import contextlib
-import ipaddress
+import hmac
 
 from django.conf import settings
 from django.contrib import admin
@@ -26,25 +26,28 @@ from applications.frontend.views import (
 
 
 def metrics_view(request):
-    """Serve Prometheus metrics only to requests from PROMETHEUS_ALLOWED_HOSTS.
+    """Serve Prometheus metrics only to requests bearing the correct scrape token.
 
-    Each entry can be an exact IP address or a CIDR network (e.g. 172.19.0.0/24).
+    Prometheus must send:
+        Authorization: Bearer <METRICS_SCRAPE_TOKEN>
+
+    The token is compared with hmac.compare_digest to prevent timing attacks.
+    Set METRICS_SCRAPE_TOKEN in Doppler; if unset the endpoint is always denied.
     """
-    allowed = getattr(settings, "PROMETHEUS_ALLOWED_HOSTS", [])
-    remote = request.META.get("REMOTE_ADDR", "")
-    try:
-        remote_ip = ipaddress.ip_address(remote)
-    except ValueError:
+    expected = getattr(settings, "METRICS_SCRAPE_TOKEN", "")
+    if not expected:
         return HttpResponseForbidden()
 
-    for entry in allowed:
-        try:
-            if remote_ip in ipaddress.ip_network(entry, strict=False):
-                return ExportToDjangoView(request)
-        except ValueError:
-            continue
+    auth_header = request.META.get("HTTP_AUTHORIZATION", "")
+    scheme, _, provided = auth_header.partition(" ")
 
-    return HttpResponseForbidden()
+    if scheme.lower() != "bearer" or not provided:
+        return HttpResponseForbidden()
+
+    if not hmac.compare_digest(provided.strip(), expected):
+        return HttpResponseForbidden()
+
+    return ExportToDjangoView(request)
 
 
 urlpatterns = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,9 @@ testpaths = [
   "applications/API/tests",
   "applications/graphQL/tests",
   "applications/frontend/tests",
+  "core/tests",
+  "common/tests"
+
 ]
 
 [tool.djlint]
@@ -109,24 +112,28 @@ django_settings_module = "thedozens.settings"
 
 [tool.coverage.run]
 branch = true
-source = ["applications"]
+source = ["applications", "core", "common"]
 omit = [
-  "*/migrations/*",
-  "*/tests/*",
-  "manage.py",
-  "*/venv/*",
-  "*/.venv/*",
+    "*/wsgi.py",
+    "*/asgi.py",
+    "core/storage_backends.py",
+    "core/apps.py",
+    "applications/*/apps.py",
+    "applications/API/schema_extensions.py",
+    "applications/ld_integration/management/*",
 ]
 
 [tool.coverage.report]
 skip_empty = true
 show_missing = true
-omit = [
-  "*/migrations/*",
-  "*/tests/*",
-  "manage.py",
-  "*/venv/*",
-  "*/.venv/*",
+ omit = [
+    "*/wsgi.py",
+    "*/asgi.py",
+    "core/storage_backends.py",
+    "core/apps.py",
+    "applications/*/apps.py",
+    "applications/API/schema_extensions.py",
+    "applications/ld_integration/management/*",
 ]
 exclude_lines = [
   "pragma: no cover",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,8 @@ django_settings_module = "thedozens.settings"
 branch = true
 source = ["applications", "core", "common"]
 omit = [
+    "*/tests/*",
+   "*/migrations/*",
     "*/wsgi.py",
     "*/asgi.py",
     "core/storage_backends.py",
@@ -126,7 +128,9 @@ omit = [
 [tool.coverage.report]
 skip_empty = true
 show_missing = true
- omit = [
+omit = [
+    "*/tests/*",
+    "*/migrations/*",
     "*/wsgi.py",
     "*/asgi.py",
     "core/storage_backends.py",


### PR DESCRIPTION
- Introduced tests for common.metrics._MetricsFacade, covering cache increments, database query timing, random insult metrics, and endpoint cache handling.
- Implemented tests for common.middleware.RequestIDMiddleware, ensuring proper request ID propagation, UUID generation, and Loguru context management.
- Updated core settings to replace IP-based metrics scraping with a bearer token mechanism, enhancing security.
- Refactored metrics view tests to validate the new bearer token authentication, ensuring correct handling of valid and invalid tokens.
- Adjusted coverage settings to include core and common directories, ensuring thorough test coverage across the application.

## Summary by Sourcery

Switch metrics scraping to bearer-token authentication and add comprehensive tests and configuration updates around metrics, caching, and middleware.

New Features:
- Introduce bearer-token authentication for the /metrics endpoint driven by the METRICS_SCRAPE_TOKEN setting.
- Add structured SQL instrumentation helpers and metrics usage tests for cache, database, and endpoint operations.
- Introduce dedicated test suites for cache manager utilities and request ID middleware behavior.

Bug Fixes:
- Prevent potential deadlocks in cache managers by using a re-entrant lock for internal cache locking.

Enhancements:
- Tighten /metrics access control to require a valid Authorization: Bearer token and handle malformed or missing credentials with 403 responses.
- Expand cache manager utilities to expose stats and support robust invalidation across registered managers.
- Refine Prometheus scrape configuration to rely on bearer tokens instead of IP allowlists.

Build:
- Broaden pytest discovery and coverage sources to include core and common modules while updating coverage omit rules for non-critical files.

Deployment:
- Update Prometheus deployment configuration to send bearer tokens from a credentials file when scraping the Django metrics endpoint.

Documentation:
- Clarify in settings and Prometheus config comments that metrics scraping now uses bearer tokens instead of IP-based allowlists.

Tests:
- Add extensive tests for the metrics view to validate bearer-token authentication and edge cases.
- Add a comprehensive test suite for cache manager registry, category/form-choice managers, and generic data cache managers.
- Add tests for metrics facade behavior, covering cache, database, random insult, and endpoint cache metrics.
- Add tests for RequestIDMiddleware to verify request ID propagation, UUID generation, response headers, and Loguru context usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for cache managers, metrics functionality, and middleware request ID handling.
  * Updated metrics endpoint authentication tests for bearer token validation.

* **Chores**
  * Metrics endpoint authentication changed from IP allowlist to bearer token validation.
  * Updated test discovery paths and coverage configuration in project settings.
  * Enhanced internal synchronization mechanism for cache operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->